### PR TITLE
Bugfix, create new session on order creation if it does not exist

### DIFF
--- a/Observers/OrderCreateObserver.php
+++ b/Observers/OrderCreateObserver.php
@@ -73,7 +73,7 @@ class OrderCreateObserver implements ObserverInterface
             $order = $observer->getEvent()->getOrder();
             $diggerId = $order->getData('digger_id');
 
-            $sessionId = $this->session->getDiggerSessionId();
+            $sessionId = $this->session->getDiggerSessionId() ?? $this->generateUuid();
             $currentPath = $this->urlInterface->getCurrentUrl();
             $trackingCode = $this->session->getTrackingCode() ?? '';
             $referrer = $this->session->getReferer() ?? '';
@@ -102,5 +102,25 @@ class OrderCreateObserver implements ObserverInterface
         } catch (\Throwable $t) {
             $this->logger->critical($t);
         }
+    }
+
+    /**
+     * Generate a GUID.
+     *
+     * @return string
+     */
+    private function generateUuid()
+    {
+        return sprintf(
+            '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
+            random_int(0, 0xFFFF),
+            random_int(0, 0xFFFF),
+            random_int(0, 0xFFFF),
+            random_int(0, 0x0FFF) | 0x4000,
+            random_int(0, 0x3FFF) | 0x8000,
+            random_int(0, 0xFFFF),
+            random_int(0, 0xFFFF),
+            random_int(0, 0xFFFF)
+        );
     }
 }


### PR DESCRIPTION
This is the error message we've been getting in the checkout from de digger module:
I haven't had the time to look at it. Possibly some configuration issue?
 
[2023-02-21 13:46:06] main.CRITICAL: TypeError: Argument 1 passed to Digtective\Digger\Model\Data\DiggerConsumerRequest::setDiggerSessionId() must be of the type string, null given, called in /data/web/magento2/app/code/Digtective/Digger/Observers/OrderCreateObserver.php on line 89 and defined in /data/web/magento2/app/code/Digtective/Digger/Model/Data/DiggerConsumerRequest.php:53
Stack trace:
#0 /data/web/magento2/app/code/Digtective/Digger/Observers/OrderCreateObserver.php(89): Digtective\Digger\Model\Data\DiggerConsumerRequest->setDiggerSessionId()
#1 