### PR TITLE
Bugfix, Type of 'connection' field specified in configuration  error when doing setup:upgrade

### DIFF
--- a/Consumer/DiggerConsumer.php
+++ b/Consumer/DiggerConsumer.php
@@ -51,9 +51,10 @@ class DiggerConsumer
      * Process queue
      *
      * @param DiggerConsumerRequestInterface $diggerConsumerRequest
+     * @return void
      * @throws LocalizedException
      */
-    public function process(DiggerConsumerRequestInterface $diggerConsumerRequest)
+    public function process(DiggerConsumerRequestInterface $diggerConsumerRequest) : void
     {
         switch ($diggerConsumerRequest->getRequestType()) {
             case DiggerConsumerRequestInterface::REQUEST_TYPE_CREATE_ORDER:

--- a/etc/queue_publisher.xml
+++ b/etc/queue_publisher.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-        xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/consumer.xsd">
+        xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/publisher.xsd">
     <publisher topic="digger.request" />
 </config>

--- a/etc/queue_topology.xml
+++ b/etc/queue_topology.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
         xsi:noNamespaceSchemaLocation="urn:magento:framework-message-queue:etc/topology.xsd">
-    <exchange name="digger-queue-exchange" type="topic">
+    <exchange name="magento">
         <binding id="DiggerQueueBinding"
                  topic="digger.request"
                  destinationType="queue"


### PR DESCRIPTION
we had some problems installing your module. After bin/magento setup:upgrade we always see:

"Type of 'connection' field specified in configuration of 'digger-queue-exchange--' exchange is invalid. Given 'NULL', 'string' was expected."